### PR TITLE
Handle JFIF headers.

### DIFF
--- a/piexif/_common.py
+++ b/piexif/_common.py
@@ -41,10 +41,20 @@ def read_exif_from_file(filename):
     while 1:
         length = struct.unpack(">H", head[2: 4])[0]
 
-        if head[:2] == b"\xff\xe1":
+        if head[:2] == b"\xff\xe0":
             segment_data = f.read(length - 2)
-            exif = head + segment_data
-            break
+            # print("APP0 segment identification is:", segment_data[:4])
+            head = f.read(HEAD_LENGTH)
+        elif head[:2] == b"\xff\xe1":
+            segment_data = f.read(length - 2)
+            # print("APP1 segment identification is:", segment_data[:4])
+            if segment_data[:4] == b'Exif':
+                # return 'Exif' data segment
+                exif = head + segment_data
+                break
+            else:
+                # skip this data segment
+                head = f.read(HEAD_LENGTH)
         elif head[0:1] == b"\xff":
             f.read(length - 2)
             head = f.read(HEAD_LENGTH)

--- a/piexif/_common.py
+++ b/piexif/_common.py
@@ -74,28 +74,20 @@ def get_exif_seg(segments):
 
 
 def merge_segments(segments, exif=b""):
-    """Merges Exif with APP0 and APP1 manipulations.
+    """Merges Exif with APP1 manipulations.
     """
-    if segments[1][0:2] == b"\xff\xe0" and \
-       segments[2][0:2] == b"\xff\xe1" and \
-       segments[2][4:10] == b"Exif\x00\x00":
-        if exif:
-            segments[2] = exif
-            segments.pop(1)
-        elif exif is None:
-            segments.pop(2)
-        else:
-            segments.pop(1)
-    elif segments[1][0:2] == b"\xff\xe0":
-        if exif:
-            segments[1] = exif
-    elif segments[1][0:2] == b"\xff\xe1" and \
-         segments[1][4:10] == b"Exif\x00\x00":
-        if exif:
-            segments[1] = exif
-        elif exif is None:
-            segments.pop(1)
-    else:
-        if exif:
-            segments.insert(1, exif)
+    found = False
+    for i in range(0, len(segments)):
+        if segments[i][0:2] == b"\xff\xe1" and \
+           segments[i][4:10] == b"Exif\x00\x00":
+            if not found and exif is not None:
+                # replace first occurence of APP1:Exif segment
+                # print("REPLACING Exif seg %d.." % i)
+                segments[i] = exif
+                found = True
+            else:
+                # remove additional occurences of APP1:Exif segment
+                # print("REMOVE Exif seg %d.." % i)
+                segments.pop(i)
     return b"".join(segments)
+        

--- a/piexif/_common.py
+++ b/piexif/_common.py
@@ -77,6 +77,9 @@ def merge_segments(segments, exif=b""):
     """Merges Exif with APP1 manipulations.
     """
     found = False
+
+    import pdb; pdb.set_trace()
+
     for i in range(0, len(segments)):
         if segments[i][0:2] == b"\xff\xe1" and \
            segments[i][4:10] == b"Exif\x00\x00":
@@ -89,5 +92,10 @@ def merge_segments(segments, exif=b""):
                 # remove additional occurences of APP1:Exif segment
                 # print("REMOVE Exif seg %d.." % i)
                 segments.pop(i)
+
+    # no Exif segment in the image, create one now if exists
+    if not found and exif:
+        segments.insert(1, exif)
+
     return b"".join(segments)
-        
+

--- a/piexif/_common.py
+++ b/piexif/_common.py
@@ -78,8 +78,6 @@ def merge_segments(segments, exif=b""):
     """
     found = False
 
-    import pdb; pdb.set_trace()
-
     for i in range(0, len(segments)):
         if segments[i][0:2] == b"\xff\xe1" and \
            segments[i][4:10] == b"Exif\x00\x00":

--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -6,6 +6,7 @@ from ._exif import *
 
 
 LITTLE_ENDIAN = b"\x49\x49"
+BIG_ENDIAN = b"\x4D\x4D"
 
 
 def load(input_data, key_is_name = False):
@@ -30,8 +31,11 @@ def load(input_data, key_is_name = False):
 
     if exifReader.tiftag[0:2] == LITTLE_ENDIAN:
         exifReader.endian_mark = "<"
-    else:
+    elif exifReader.tiftag[0:2] == BIG_ENDIAN:
         exifReader.endian_mark = ">"
+    else:
+        print("Exif header is invalid: %X %X" % (exifReader.tiftag[0], exifReader.tiftag[1]))
+        return exif_dict
 
     pointer = struct.unpack(exifReader.endian_mark + "L",
                             exifReader.tiftag[4:8])[0]


### PR DESCRIPTION
This change skips over JFIF EXIF headers and finds JPEG EXIF header, if it exists.
Minor change to detection of JPEG endinaness in order to make library more roboust.